### PR TITLE
feat(server): configure dotenv and add env variable validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGO_URI=

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,11 @@
+require('dotenv').config();
+
+const requiredVars = ['MONGO_URI'];
+requiredVars.forEach((key) => {
+  if (!process.env[key]) {
+    console.error(`❌ Missing required environment variable: ${key}`);
+    process.exit(1);
+  }
+});
+
+console.log('✅ Environment variables loaded successfully.');

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "server",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.5.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -8,5 +8,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "dotenv": "^16.5.0"
+  }
 }


### PR DESCRIPTION
### ✨ Summary
-----------------------------------------------------------------------------------------------------------------------------------------------
This PR addresses Issue #4 by setting up environment variable management for the server.

### ✅ Changes Made

- Installed `dotenv` in the `server/` directory.
- Created `server/index.js` as the server's entry point.
- Configured `dotenv` to load environment variables.
- Added validation to exit with an error if required env vars (e.g. `MONGO_URI`) are missing.
- Added `.env.example` with placeholder keys.
- Ensured `.env` is listed in `.gitignore`.

### 🧪 Test Steps

1. Create a `.env` file in `/server` with:
MONGO_URI=your_connection_string
2. Run `node index.js` inside the `/server` directory.
3. It should print ✅ Environment variables loaded successfully.
4. Delete `MONGO_URI` from `.env` and run again — it should print an error and exit.

-----------------------------------------------------------------------------------------------------------------------------------------------

Closes #4 ✅