### PR TITLE
feat(server): Create Mongoose schemas for Volunteer and Organization

### DIFF
--- a/server/models/organizationModel.js
+++ b/server/models/organizationModel.js
@@ -1,0 +1,28 @@
+const mongoose = require("mongoose");
+
+const organizationSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: [true, "Please add a name"],
+    },
+    email: {
+      type: String,
+      required: [true, "Please add an email"],
+      unique: true,
+    },
+    description: {
+      type: String,
+      required: [true, "Please add a description"],
+    },
+    postedOpportunities: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Opportunity",
+      },
+    ],
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("Organization", organizationSchema);

--- a/server/models/volunteerModel.js
+++ b/server/models/volunteerModel.js
@@ -1,0 +1,30 @@
+const mongoose = require("mongoose");
+
+const volunteerSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: [true, "Please add a name"],
+    },
+    email: {
+      type: String,
+      required: [true, "Please add an email"],
+      unique: true,
+    },
+    skills: {
+      type: [String],
+      required: [true, "Please add a skill"],
+    },
+    availability: {
+      days: {
+        type: [String],
+      },
+      times: {
+        type: String,
+      },
+    },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("Volunteer", volunteerSchema);


### PR DESCRIPTION
This pull request resolves Issue #7.

**Description:**

I have created the initial Mongoose schemas for the `Volunteer` and `Organization` models as specified.

**Changes:**

- Created `backend/models/volunteerModel.js` with fields for `name`, `email`, `skills` (as an array), and `availability` (as an object).
  - For `availability`, I set `days` as an array and `times` as a string. I wasn't 100% sure how to handle this, so I'm happy to make adjustments based on feedback!
- Created `backend/models/organizationModel.js` with fields for `name`, `email`, `description`, and `postedOpportunities`.
  - For `postedOpportunities`, I used a reference to an `'Opportunity'` model, assuming it will be created based on Git issue 8. This may need to be updated later.
- Optionally added `{ timestamps: true }` to both schemas to track `createdAt` and `updatedAt` fields.

Please let me know if any changes are needed and I'll fix asap!